### PR TITLE
Add secure CLI login with token-based authentication and macOS Keychain support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,14 @@
 AllCops:
   TargetRubyVersion: 3.1
-
+  NewCops: enable
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/AbcSize:
+  Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 
 Metrics/AbcSize:
   Max: 20

--- a/exe/toknsmith
+++ b/exe/toknsmith
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require_relative "../lib/toknsmith/cli"
 Toknsmith::CLI.start(ARGV)

--- a/lib/toknsmith/cli.rb
+++ b/lib/toknsmith/cli.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 require "thor"
 require_relative "client"
 require_relative "keychain"
 require_relative "client_config"
 
 module Toknsmith
+  # A command-line interface for logging in and saving tokens
   class CLI < Thor
     def self.exit_on_failure?
       true

--- a/lib/toknsmith/cli.rb
+++ b/lib/toknsmith/cli.rb
@@ -4,7 +4,7 @@ require "thor"
 require_relative "client"
 require_relative "keychain"
 require_relative "client_config"
-
+require "io/console"
 module Toknsmith
   # A command-line interface for logging in and saving tokens
   class CLI < Thor
@@ -20,10 +20,26 @@ module Toknsmith
       puts "Error: #{e.message}"
     end
 
-    desc "login TOKEN", "Store your auth token securely in macOS keychain"
-    def login(token)
-      Keychain.save(token)
-      puts "✅ Token saved securely to Keychain!"
+    desc "login", "Log in with your email and password to receive an auth token"
+    def login
+      print "Email: "
+      email = $stdin.gets.strip
+
+      print "Password: "
+      password = $stdin.noecho(&:gets).strip
+      puts "\nLogging in..."
+
+      client = Client.new
+      auth_token = client.login(email, password)
+
+      if auth_token
+        Keychain.save(auth_token)
+        puts "✅ Logged in and token saved to Keychain!"
+      else
+        puts "❌ Login failed. Please check your credentials."
+      end
+    rescue StandardError => e
+      puts "Error during login: #{e.message}"
     end
   end
 end

--- a/lib/toknsmith/client.rb
+++ b/lib/toknsmith/client.rb
@@ -33,8 +33,10 @@ module Toknsmith
         "#{@config.api_base}/api/v1/login",
         headers: { "Content-Type" => "application/json" },
         body: {
-          email: email,
-          password: password
+          session: {
+            email: email,
+            password: password
+          }
         }.to_json
       )
 

--- a/lib/toknsmith/client.rb
+++ b/lib/toknsmith/client.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 require "httparty"
 require_relative "client_config"
+require "json"
 
 module Toknsmith
+  # Handles API interactions including authentication and identity verification.
   class Client
     def initialize
       @config = ClientConfig.new

--- a/lib/toknsmith/client.rb
+++ b/lib/toknsmith/client.rb
@@ -27,5 +27,24 @@ module Toknsmith
         puts "Failed to authenticate. Status: #{response.code}"
       end
     end
+
+    def login(email, password)
+      response = HTTParty.post(
+        "#{@config.api_base}/api/v1/login",
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          email: email,
+          password: password
+        }.to_json
+      )
+
+      case response.code
+      when 200
+        response["auth_token"]
+      else
+        puts "Error: #{response.parsed_response["error"] || "Unknown error"}"
+        nil
+      end
+    end
   end
 end

--- a/lib/toknsmith/client_config.rb
+++ b/lib/toknsmith/client_config.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require_relative "keychain"
 require "yaml"
 
 module Toknsmith
+  # Loads CLI configuration from the user's home directory and retrieves stored auth tokens.
   class ClientConfig
     CONFIG_PATH = File.join(Dir.home, ".toknsmith", "config")
 

--- a/lib/toknsmith/keychain.rb
+++ b/lib/toknsmith/keychain.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require "shellwords"
 
 module Toknsmith
+  # Provides methods to save, load, and delete auth tokens in the macOS Keychain.
   class Keychain
     SERVICE = "toknsmith"
     ACCOUNT = "auth_token"

--- a/toknsmith-cli.gemspec
+++ b/toknsmith-cli.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~> 1.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ToriK17/toknsmith-cli"


### PR DESCRIPTION
**Changes**
- Implements secure login flow from the CLI using email/password authentication
- Communicates with the Rails API to retrieve a hashed auth token
- Stores the received token securely in macOS Keychain
- Adds support for authenticated `whoami` requests using the stored token

**Why**
This is the foundation of secure CLI usage. By storing session tokens in the system keychain, users stay authenticated between sessions without exposing credentials on disk.

Combined with the Toknsmith API’s new `AccessToken` model, this completes the first end-to-end loop:
- Authenticate
- Store token securely
- Securely verify identity via token

