### PR TITLE
Add logout command to remove stored token from macOS Keychain

### DIFF
--- a/lib/toknsmith/cli.rb
+++ b/lib/toknsmith/cli.rb
@@ -41,5 +41,16 @@ module Toknsmith
     rescue StandardError => e
       puts "Error during login: #{e.message}"
     end
+
+    desc "logout", "Remove your stored auth token from local keychain"
+    def logout
+      if Keychain.clear
+        puts "👋 Logged out. Token removed from Keychain."
+      else
+        puts "⚠️ No token found in Keychain."
+      end
+    rescue StandardError => e
+      puts "Error during logout: #{e.message}"
+    end
   end
 end

--- a/lib/toknsmith/keychain.rb
+++ b/lib/toknsmith/keychain.rb
@@ -19,5 +19,9 @@ module Toknsmith
     def self.delete
       system("security delete-generic-password -a #{ACCOUNT} -s #{SERVICE} 2>/dev/null")
     end
+
+    def self.clear
+      system("security delete-generic-password -s toknsmith -a auth_token >/dev/null 2>&1")
+    end
   end
 end


### PR DESCRIPTION
**Changes**
- Adds a `logout` command to the Toknsmith CLI
- Securely removes the stored auth token from the macOS Keychain
- Prevents unintended verbose output from `security` command
- Confirms logout with clean, user-friendly messaging

**Why**
Users can now explicitly end their session from the CLI, removing all local token traces.
Logout feedback is clean and clear:
