### PR TITLE
Full logout support with remote token revocation

### DIFF
--- a/lib/toknsmith/cli.rb
+++ b/lib/toknsmith/cli.rb
@@ -42,10 +42,13 @@ module Toknsmith
       puts "Error during login: #{e.message}"
     end
 
-    desc "logout", "Remove your stored auth token from local keychain"
+    desc "logout", "Revoke your auth token and remove it from local keychain"
     def logout
+      client = Client.new
+      client.logout
+
       if Keychain.clear
-        puts "👋 Logged out. Token removed from Keychain."
+        puts "👋 Logged out locally. Token removed from Keychain."
       else
         puts "⚠️ No token found in Keychain."
       end

--- a/lib/toknsmith/client.rb
+++ b/lib/toknsmith/client.rb
@@ -48,5 +48,24 @@ module Toknsmith
         nil
       end
     end
+
+    def logout
+      response = HTTParty.delete(
+        "#{@config.api_base}/api/v1/logout",
+        headers: {
+          "Authorization" => "Bearer #{@config.auth_token}",
+          "Content-Type" => "application/json"
+        }
+      )
+
+      case response.code
+      when 200
+        puts "✅ Token revoked remotely."
+      when 401
+        puts "⚠️ Token already revoked or invalid."
+      else
+        puts "Error: #{response.parsed_response["error"] || "Unknown error"}"
+      end
+    end
   end
 end


### PR DESCRIPTION
**Changes**
- Adds support for API-based token revocation via DELETE /api/v1/logout
- CLI logout now calls the API before clearing local Keychain token to revoke token and provide audit logs
- Ensures auth token is fully invalidated both remotely and locally
- Prevents zombie sessions and aligns with secure token lifecycle best practices
<img width="667" alt="Screenshot 2025-04-23 at 10 28 27 AM" src="https://github.com/user-attachments/assets/50915841-3332-4e28-b86e-d365295c9872" />


