### PR TITLE
Add tokens list command to display stored service tokens

### DIFF
--- a/lib/toknsmith/client.rb
+++ b/lib/toknsmith/client.rb
@@ -79,6 +79,24 @@ module Toknsmith
       post_token(body)
     end
 
+    def list_tokens
+      response = HTTParty.get(
+        "#{@config.api_base}/api/v1/tokens",
+        headers: {
+          "Authorization" => "Bearer #{@config.auth_token}",
+          "Content-Type" => "application/json"
+        }
+      )
+
+      case response.code
+      when 200
+        response.parsed_response
+      else
+        puts "Error: #{response.parsed_response["error"] || "Unknown error"}"
+        []
+      end
+    end
+
     private
 
     def post_token(body)

--- a/lib/toknsmith/tokens.rb
+++ b/lib/toknsmith/tokens.rb
@@ -24,6 +24,24 @@ module Toknsmith
       puts "Error: #{e.message}"
     end
 
+    desc "list", "List stored tokens for your team"
+    def list
+      client = Client.new
+      tokens = client.list_tokens
+
+      if tokens.any?
+        puts "🔐 Stored Tokens:"
+        puts "ID\tService\t\tExpires\t\t\tNote"
+        tokens.each do |t|
+          puts "#{t["id"]}\t#{t["service_name"]}\t#{t["expires_at"] || "Never"}\t#{t["note"] || "-"}"
+        end
+      else
+        puts "😴 No tokens stored yet."
+      end
+    rescue StandardError => e
+      puts "Error: #{e.message}"
+    end
+
     private
 
     def print_token_result(service, response)


### PR DESCRIPTION
- Adds `toknsmith tokens list` CLI command
- Fetches current team’s tokens from API
- Displays ID, service, expiration, and notes in a readable format
- Helps users validate stored secrets without touching the DB
- This completes the first full token management loop via CLI.

![Uploading Screenshot 2025-04-24 at 2.28.37 PM.png…]()


