### PR TITLE
fully round-tripped OAuth flow with cloud-enforced encryption and CLI integration

### DIFF
--- a/lib/toknsmith/oauth.rb
+++ b/lib/toknsmith/oauth.rb
@@ -37,5 +37,47 @@ module Toknsmith
     rescue StandardError => e
       puts "Error during OAuth configuration: #{e.message}"
     end
+
+    desc "connect SERVICE", "Initiate OAuth connection for a service (e.g. github)"
+    def connect(service)
+      client = Client.new
+      auth_token = client.auth_token
+      unless auth_token
+        puts "❌ No auth token found. Please login first with `toknsmith login`."
+        return
+      end
+
+      oauth_config = client.fetch_oauth_config(service)
+
+      unless oauth_config
+        puts "❌ No OAuth config found for #{service}."
+        return
+      end
+
+      client_id = oauth_config["client_id"]
+      # NOTE: we don't need client_secret here, only client_id for GitHub authorize link
+
+      redirect_uri = "http://localhost:7071/api/github-callback"
+      query = URI.encode_www_form(
+        client_id: client_id,
+        redirect_uri: redirect_uri,
+        state: "toknsmith:#{auth_token}"
+      )
+      oauth_url = "http://localhost:7071/api/github-authorize?#{query}"
+
+      puts "🌐 Open this URL to connect your GitHub account:"
+      puts oauth_url
+      # Optional: auto-open browser
+      case RbConfig::CONFIG["host_os"]
+      when /darwin|mac os/
+        system("open", oauth_url)
+      when /linux/
+        system("xdg-open", oauth_url)
+      when /mswin|mingw|cygwin/
+        system("start", oauth_url)
+      end
+    rescue StandardError => e
+      puts "Error starting OAuth flow: #{e.message}"
+    end
   end
 end

--- a/lib/toknsmith/tokens.rb
+++ b/lib/toknsmith/tokens.rb
@@ -43,48 +43,6 @@ module Toknsmith
       puts "Error: #{e.message}"
     end
 
-    desc "connect SERVICE", "Initiate OAuth connection for a service (e.g. github)"
-    def connect(service)
-      client = Client.new
-      auth_token = client.auth_token
-      unless auth_token
-        puts "❌ No auth token found. Please login first with `toknsmith login`."
-        return
-      end
-
-      oauth_config = client.fetch_oauth_config(service)
-
-      unless oauth_config
-        puts "❌ No OAuth config found for #{service}."
-        return
-      end
-
-      client_id = oauth_config["client_id"]
-      # NOTE: we don't need client_secret here, only client_id for GitHub authorize link
-
-      redirect_uri = "http://localhost:7071/api/github-callback"
-      query = URI.encode_www_form(
-        client_id: client_id,
-        redirect_uri: redirect_uri,
-        state: "toknsmith:#{auth_token}"
-      )
-      oauth_url = "http://localhost:7071/api/github-authorize?#{query}"
-
-      puts "🌐 Open this URL to connect your GitHub account:"
-      puts oauth_url
-      # Optional: auto-open browser
-      case RbConfig::CONFIG["host_os"]
-      when /darwin|mac os/
-        system("open", oauth_url)
-      when /linux/
-        system("xdg-open", oauth_url)
-      when /mswin|mingw|cygwin/
-        system("start", oauth_url)
-      end
-    rescue StandardError => e
-      puts "Error starting OAuth flow: #{e.message}"
-    end
-
     private
 
     def print_token_result(service, response)


### PR DESCRIPTION
**Changes**
- Added a CLI command for connect properly scoped in the Oauth subcommand.
This now works with middleware and API to authorize a user and issue a short lived OAuth token that can be used for future rotation. 